### PR TITLE
First instalment of unified memory model

### DIFF
--- a/ScriptCompiler/Register.cs
+++ b/ScriptCompiler/Register.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Runtime.ConstrainedExecution;
+
+namespace ScriptCompiler {
+    public class Register : IDisposable {
+        public readonly int Number;
+        private readonly Action _dispose;
+        
+        public Register(int number, Action dispose) {
+            Number = number;
+            _dispose = dispose;
+        }
+
+        public override string ToString() {
+            return $"r{Number}";
+        }
+
+        public void Dispose() {
+            _dispose();
+        }
+    }
+}

--- a/ScriptCompiler/Visitors/ExpressionGenVisitor.cs
+++ b/ScriptCompiler/Visitors/ExpressionGenVisitor.cs
@@ -7,61 +7,70 @@ using ScriptCompiler.AST;
 namespace ScriptCompiler.Visitors {
     // TODO: Abstraction over string
     // Returns <commands>, <result register/location>
-    public class ExpressionGenVisitor : Visitor<(List<string>, string)> {
+    public class ExpressionGenVisitor : Visitor<(List<string>, Register)> {
         private readonly CodeGenVisitor _codeGenVisitor;
 
         public ExpressionGenVisitor(CodeGenVisitor codeGenVisitor) {
             _codeGenVisitor = codeGenVisitor;
         }
 
-        public (List<string>, string) VisitDynamic(ASTNode node) {
-            (List<string>, string) res = Visit(node as dynamic);
-            return (res.Item1, res.Item2);
+        public (List<string>, Register) VisitDynamic(ASTNode node) {
+            (List<string>, Register) res = Visit(node as dynamic);
+            return res;
         }
 
-        public override (List<string>, string) Visit(ASTNode node) {
-            throw new System.NotImplementedException(node.GetType().FullName);
+        public override (List<string>, Register) Visit(ASTNode node) {
+            throw new NotImplementedException(node.GetType().FullName);
         }
 
-        public (List<string>, string) Visit(StringLiteralNode node) {
+        public (List<string>, Register) Visit(StringLiteralNode node) {
             // TODO: node.Throw()
             if (!_codeGenVisitor.StringAliases.ContainsKey(node.String)) {
                 throw new ArgumentException();
             }
 
-            return (new List<string>(), "!" + _codeGenVisitor.StringAliases[node.String]);
+            List<string> commands = new List<string>();
+            // Put a pointer to the string into a register
+            var register = _codeGenVisitor.GetRegister();
+            commands.Add($"MOV {register} !{_codeGenVisitor.StringAliases[node.String]}");
+            
+            return (commands, register);
         }
 
-        public (List<string>, string) Visit(IntegerLiteralNode node) {
-            return (new List<string>(), node.value.ToString());
+        public (List<string>, Register) Visit(IntegerLiteralNode node) {
+            var register = _codeGenVisitor.GetRegister();
+            return (new List<string>() { $"MOV {register} {node.value}" }, register);
         }
 
-        public (List<string>, string) Visit(AdditionNode node) {
+        public (List<string>, Register) Visit(AdditionNode node) {
             return VisitBinOpNode(node, "ADD");
         }
 
-        public (List<string>, string) Visit(SubtractionNode node) {
+        public (List<string>, Register) Visit(SubtractionNode node) {
             return VisitBinOpNode(node, "SUB");
         }
 
-        public (List<string>, string) Visit(MultiplicationNode node) {
+        public (List<string>, Register) Visit(MultiplicationNode node) {
             return VisitBinOpNode(node, "MUL");
         }
 
-        public (List<string>, string) Visit(DivisionNode node) {
+        public (List<string>, Register) Visit(DivisionNode node) {
             return VisitBinOpNode(node, "DIV");
         }
         
-        public (List<string>, string) VisitBinOpNode(BinaryOperatorNode node, string opCommand) {
+        public (List<string>, Register) VisitBinOpNode(BinaryOperatorNode node, string opCommand) {
             List<string> commands = new List<string>();
             var (commandsL, resultL) = VisitDynamic(node.Left);
             var (commandsR, resultR) = VisitDynamic(node.Right);
-            commands.AddRange(commandsL);
-            commands.AddRange(commandsR);
-            var register = _codeGenVisitor.GetRegister();
-            commands.Add($"MOV {register} {resultL}");
-            commands.Add($"{opCommand} {register} {resultR}");
-            return (commands, register);
+            using (resultL)
+            using (resultR) {
+                commands.AddRange(commandsL);
+                commands.AddRange(commandsR);
+                var register = _codeGenVisitor.GetRegister();
+                commands.Add($"MOV {register} {resultL}");
+                commands.Add($"{opCommand} {register} {resultR}");
+                return (commands, register);
+            }
         }
     }
 }

--- a/ScriptCompiler/Visitors/IRegisterAllocator.cs
+++ b/ScriptCompiler/Visitors/IRegisterAllocator.cs
@@ -1,5 +1,5 @@
 ﻿namespace ScriptCompiler.Visitors {
     public interface IRegisterAllocator {
-        string GetRegister();
+        Register GetRegister();
     }
 }


### PR DESCRIPTION
This PR:

- Is the first step to a unified memory model for the scripting language, so that accesses to constant string literals and generated strings on the heap or stack can be treated the same at a low level
- Begins register reuse by creating a disposable register object
- Unifies stack loading in the assembler by treating "!" as a general prefix instead of a special case in string printing