### PR TITLE
Stack variables

### DIFF
--- a/ScriptCompiler/AST/CodeBlockNode.cs
+++ b/ScriptCompiler/AST/CodeBlockNode.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ScriptCompiler.AST.Statements;
 
 namespace ScriptCompiler.AST {
     public class CodeBlockNode : ASTNode {

--- a/ScriptCompiler/AST/ProgramNode.cs
+++ b/ScriptCompiler/AST/ProgramNode.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ScriptCompiler.AST.Statements;
 
 namespace ScriptCompiler.AST {
     public class ProgramNode : ASTNode {

--- a/ScriptCompiler/AST/Statements/AssignmentStatementNode.cs
+++ b/ScriptCompiler/AST/Statements/AssignmentStatementNode.cs
@@ -1,0 +1,5 @@
+﻿namespace ScriptCompiler.AST.Statements {
+    public class AssignmentStatementNode : StatementNode {
+        
+    }
+}

--- a/ScriptCompiler/AST/Statements/DeclarationStatementNode.cs
+++ b/ScriptCompiler/AST/Statements/DeclarationStatementNode.cs
@@ -1,0 +1,17 @@
+﻿using ScriptCompiler.AST.Statements.Expressions;
+
+namespace ScriptCompiler.AST.Statements {
+    public class DeclarationStatementNode : StatementNode {
+        public readonly string TypeString;
+        public readonly string Identifier;
+        public readonly ExpressionNode InitialValue;
+
+        public DeclarationStatementNode(string typeString, string identifier) : this(typeString, identifier, null) { }
+
+        public DeclarationStatementNode(string typeString, string identifier, ExpressionNode initialValue) {
+            TypeString = typeString;
+            Identifier = identifier;
+            InitialValue = initialValue;
+        }
+    }
+}

--- a/ScriptCompiler/AST/Statements/Expressions/Arithmetic/AdditionNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/Arithmetic/AdditionNode.cs
@@ -1,4 +1,4 @@
-﻿namespace ScriptCompiler.AST {
+﻿namespace ScriptCompiler.AST.Statements.Expressions.Arithmetic {
     public class AdditionNode : BinaryOperatorNode {
         public AdditionNode(ExpressionNode left, ExpressionNode right) : base(left, right) {
             

--- a/ScriptCompiler/AST/Statements/Expressions/Arithmetic/DivisionNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/Arithmetic/DivisionNode.cs
@@ -1,4 +1,4 @@
-﻿namespace ScriptCompiler.AST {
+﻿namespace ScriptCompiler.AST.Statements.Expressions.Arithmetic {
     public class DivisionNode : BinaryOperatorNode {
         public DivisionNode(ExpressionNode left, ExpressionNode right) : base(left, right) {
             

--- a/ScriptCompiler/AST/Statements/Expressions/Arithmetic/MultiplicationNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/Arithmetic/MultiplicationNode.cs
@@ -1,4 +1,4 @@
-﻿namespace ScriptCompiler.AST {
+﻿namespace ScriptCompiler.AST.Statements.Expressions.Arithmetic {
     public class MultiplicationNode : BinaryOperatorNode {
         public MultiplicationNode(ExpressionNode left, ExpressionNode right) : base(left, right) {
             

--- a/ScriptCompiler/AST/Statements/Expressions/Arithmetic/SubtractionNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/Arithmetic/SubtractionNode.cs
@@ -1,4 +1,4 @@
-﻿namespace ScriptCompiler.AST {
+﻿namespace ScriptCompiler.AST.Statements.Expressions.Arithmetic {
     public class SubtractionNode : BinaryOperatorNode {
         public SubtractionNode(ExpressionNode left, ExpressionNode right) : base(left, right) {
             

--- a/ScriptCompiler/AST/Statements/Expressions/BinaryOperatorNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/BinaryOperatorNode.cs
@@ -1,4 +1,4 @@
-﻿namespace ScriptCompiler.AST {
+﻿namespace ScriptCompiler.AST.Statements.Expressions {
     public class BinaryOperatorNode : ExpressionNode {
         public readonly ExpressionNode Left;
         public readonly ExpressionNode Right;

--- a/ScriptCompiler/AST/Statements/Expressions/ExpressionNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/ExpressionNode.cs
@@ -1,4 +1,4 @@
-﻿namespace ScriptCompiler.AST {
+﻿namespace ScriptCompiler.AST.Statements.Expressions {
     public abstract class ExpressionNode : StatementNode {
         
     }

--- a/ScriptCompiler/AST/Statements/Expressions/FunctionCallNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/FunctionCallNode.cs
@@ -1,4 +1,4 @@
-﻿namespace ScriptCompiler.AST {
+﻿namespace ScriptCompiler.AST.Statements.Expressions {
     public class FunctionCallNode : ExpressionNode {
         public readonly string FunctionName;
 

--- a/ScriptCompiler/AST/Statements/Expressions/IntegerLiteralNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/IntegerLiteralNode.cs
@@ -1,4 +1,4 @@
-﻿namespace ScriptCompiler.AST {
+﻿namespace ScriptCompiler.AST.Statements.Expressions {
     public class IntegerLiteralNode : NumericLiteralNode {
         public readonly int value;
 

--- a/ScriptCompiler/AST/Statements/Expressions/LiteralNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/LiteralNode.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace ScriptCompiler.AST {
+namespace ScriptCompiler.AST.Statements.Expressions {
     public class LiteralNode : ExpressionNode {
         public override List<ASTNode> Children() {
             return new List<ASTNode>();

--- a/ScriptCompiler/AST/Statements/Expressions/NumericLiteralNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/NumericLiteralNode.cs
@@ -1,4 +1,4 @@
-﻿namespace ScriptCompiler.AST {
+﻿namespace ScriptCompiler.AST.Statements.Expressions {
     public class NumericLiteralNode : LiteralNode {
         
     }

--- a/ScriptCompiler/AST/Statements/Expressions/StringLiteralNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/StringLiteralNode.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace ScriptCompiler.AST {
+﻿namespace ScriptCompiler.AST.Statements.Expressions {
     public class StringLiteralNode : LiteralNode {
         public readonly string String;
 

--- a/ScriptCompiler/AST/Statements/Expressions/VariableAccessNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/VariableAccessNode.cs
@@ -1,0 +1,9 @@
+﻿namespace ScriptCompiler.AST.Statements.Expressions {
+    public class VariableAccessNode : ExpressionNode {
+        public readonly string Identifier;
+        
+        public VariableAccessNode(string identifier) {
+            Identifier = identifier;
+        }
+    }
+}

--- a/ScriptCompiler/AST/Statements/PrintStatementNode.cs
+++ b/ScriptCompiler/AST/Statements/PrintStatementNode.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using ScriptCompiler.AST.Statements;
+using ScriptCompiler.AST.Statements.Expressions;
 
 namespace ScriptCompiler.AST {
     public class PrintStatementNode : StatementNode {

--- a/ScriptCompiler/AST/Statements/StatementNode.cs
+++ b/ScriptCompiler/AST/Statements/StatementNode.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 
-namespace ScriptCompiler.AST {
+namespace ScriptCompiler.AST.Statements {
     public abstract class StatementNode : ASTNode {
         public override List<ASTNode> Children() {
             return new List<ASTNode>();

--- a/ScriptCompiler/Assembler.cs
+++ b/ScriptCompiler/Assembler.cs
@@ -175,9 +175,9 @@ namespace ScriptCompiler {
                     AddInstruction(ScriptVM.Instruction.MemWrite);
                     break;
                 case "memread":
-                    HandleLoadToStack(components[1]);
                     HandleLoadToStack(components[2]);
                     AddInstruction(ScriptVM.Instruction.MemRead);
+                    HandleSaveFromStack(components[1]);
                     break;
             }
         }

--- a/ScriptCompiler/Assembler.cs
+++ b/ScriptCompiler/Assembler.cs
@@ -169,6 +169,16 @@ namespace ScriptCompiler {
                     HandleLoadToStack(components[1]);
                     AddInstruction(ScriptVM.Instruction.PrintInt);
                     break;
+                case "memwrite":
+                    HandleLoadToStack(components[1]);
+                    HandleLoadToStack(components[2]);
+                    AddInstruction(ScriptVM.Instruction.MemWrite);
+                    break;
+                case "memread":
+                    HandleLoadToStack(components[1]);
+                    HandleLoadToStack(components[2]);
+                    AddInstruction(ScriptVM.Instruction.MemRead);
+                    break;
             }
         }
 

--- a/ScriptCompiler/CompileUtil/Register.cs
+++ b/ScriptCompiler/CompileUtil/Register.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Runtime.ConstrainedExecution;
 
-namespace ScriptCompiler {
+namespace ScriptCompiler.CompileUtil {
     public class Register : IDisposable {
         public readonly int Number;
         private readonly Action _dispose;

--- a/ScriptCompiler/CompileUtil/StackFrame.cs
+++ b/ScriptCompiler/CompileUtil/StackFrame.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.WindowsRuntime;
+using ScriptCompiler.Types;
+
+namespace ScriptCompiler.CompileUtil {
+    public class StackFrame {
+        // Sometimes we want to push inaccessible variables to the stack, such as a return address during preparation
+        //  for entering a function. These affect the access to stack variables (they are all now further down the
+        //  stack) and therefore we need to keep track of how much we've "nudged" these things onto the stack
+        public int Length { get; private set; }
+        private readonly StackFrame _parent;
+        private readonly Dictionary<string, (SType, int)> _variableTable;
+
+        public StackFrame(StackFrame parent, Dictionary<string, (SType, int)> variableTable) : this(variableTable) {
+            _parent = parent;
+        }
+
+        public StackFrame(Dictionary<string, (SType, int)> parent) {
+            _variableTable = new Dictionary<string, (SType, int)>();
+            Length = 0;
+        }
+
+        /// <summary>
+        /// Gets the offset of a given identifier from the top of the stack, along with the type, providing it exists.
+        /// Otherwise, returns a NoType type, with undefined behaviour for the offset in this case.
+        /// </summary>
+        public (SType, int) Lookup(string identifier) {
+            if (_variableTable.ContainsKey(identifier)) {
+                var (type, pos) = _variableTable[identifier];
+                return (type, -Length + pos);
+            }
+            
+            if (_parent != null) {
+                var (type, pos) = _parent.Lookup(identifier);
+                return (type, pos - Length);
+            }
+
+            return (SType.SNoType, 0);
+        }
+
+        /// <summary>
+        /// Adds an identifier with a given type to the stack, and adjusts the stack length (and all consequent
+        /// accesses)
+        /// </summary>
+        public void AddIdentifier(SType type, string identifier) {
+            _variableTable[identifier] = (type, Length);
+            Length += type.Length;
+        }
+
+        /// <summary>
+        /// Given some data, allows future accesses to stack variables to account for changes on the stack
+        /// outside of the initial stack frame.
+        /// </summary>
+        public void Pushed(SType data) {
+            Length += data.Length;
+        }
+
+        /// <summary>
+        /// Undoes the changes made by Pushed for a given type
+        /// </summary>
+        public void Popped(SType data) {
+            Length -= data.Length;
+        }
+    }
+}

--- a/ScriptCompiler/CompileUtil/StackFrame.cs
+++ b/ScriptCompiler/CompileUtil/StackFrame.cs
@@ -31,7 +31,7 @@ namespace ScriptCompiler.CompileUtil {
         /// Gets the offset of a given identifier from the top of the stack, along with the type, providing it exists.
         /// Otherwise, returns a NoType type, with undefined behaviour for the offset in this case.
         /// </summary>
-        public (SType, int) Lookup(string identifier) {
+        public (SType type, int position) Lookup(string identifier) {
             if (ExistsLocalScope(identifier)) {
                 var (type, pos) = _variableTable[identifier];
                 return (type, -Length + pos);

--- a/ScriptCompiler/CompileUtil/StackFrame.cs
+++ b/ScriptCompiler/CompileUtil/StackFrame.cs
@@ -23,12 +23,16 @@ namespace ScriptCompiler.CompileUtil {
             Length = 0;
         }
 
+        public bool ExistsLocalScope(string identifier) {
+            return _variableTable.ContainsKey(identifier);
+        }
+        
         /// <summary>
         /// Gets the offset of a given identifier from the top of the stack, along with the type, providing it exists.
         /// Otherwise, returns a NoType type, with undefined behaviour for the offset in this case.
         /// </summary>
         public (SType, int) Lookup(string identifier) {
-            if (_variableTable.ContainsKey(identifier)) {
+            if (ExistsLocalScope(identifier)) {
                 var (type, pos) = _variableTable[identifier];
                 return (type, -Length + pos);
             }

--- a/ScriptCompiler/Parsing/Lexer.cs
+++ b/ScriptCompiler/Parsing/Lexer.cs
@@ -194,8 +194,8 @@ namespace ScriptCompiler.Parsing {
             return $"{this.GetType().Name}<{StringRepresentation()}> [{_line}:{_position}]";
         }
 
-        public void Throw(string message) {
-            throw new CompileException(message, _line, _position);
+        public CompileException CreateException(string message) {
+            return new CompileException(message, _line, _position);
         }
 
         protected abstract string StringRepresentation();

--- a/ScriptCompiler/Parsing/Parser.cs
+++ b/ScriptCompiler/Parsing/Parser.cs
@@ -48,6 +48,7 @@ namespace ScriptCompiler.Parsing {
             _prefixExpressionParseTable = new List<PrefixParseRule> {
                 new PrefixParseRule(t => t is IntegerToken, t => new IntegerLiteralNode(((IntegerToken) t).Content)),
                 new PrefixParseRule(t => t is StringToken, t => new StringLiteralNode(((StringToken) t).Content)),
+                new PrefixParseRule(t => t is IdentifierToken, t => new VariableAccessNode(((IdentifierToken) t).Content)),
                 new PrefixParseRule(t => t is SymbolToken s && s.Symbol == "(", _ => ParseGrouping()),
             };
 

--- a/ScriptCompiler/Parsing/Parser.cs
+++ b/ScriptCompiler/Parsing/Parser.cs
@@ -108,7 +108,6 @@ namespace ScriptCompiler.Parsing {
                         return new FunctionCallNode(identifierToken.Content);
                     // Variable declaration
                     case IdentifierToken _:
-                        Console.WriteLine("Declaration! :)");
                         // We assume that identifierToken is now a type
                         string variableType = identifierToken.Content;
                         var variableIdentifier = Expecting<IdentifierToken>().Content;

--- a/ScriptCompiler/Parsing/Parser.cs
+++ b/ScriptCompiler/Parsing/Parser.cs
@@ -5,6 +5,9 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Net.Security;
 using ScriptCompiler.AST;
+using ScriptCompiler.AST.Statements;
+using ScriptCompiler.AST.Statements.Expressions;
+using ScriptCompiler.AST.Statements.Expressions.Arithmetic;
 using ScriptCompiler.Visitors;
 
 namespace ScriptCompiler.Parsing {
@@ -89,18 +92,39 @@ namespace ScriptCompiler.Parsing {
                 return node;
             }
             
-            // TODO: Add other types of statement e.g. identifier = value
+            // TODO: Add other types of statement
             if (PeekToken() is IdentifierToken) {
                 var identifierToken = Expecting<IdentifierToken>();
-                
+
                 // Parse function call statements
-                if (PeekToken() is SymbolToken s && s.Symbol == "(") {
-                    Expecting<SymbolToken>(t => t.Symbol == "(");
-                    // TODO: Parameter lists
-                    Expecting<SymbolToken>(t => t.Symbol == ")");
-                    Expecting<SymbolToken>(t => t.Symbol == ";");
-                    
-                    return new FunctionCallNode(identifierToken.Content);
+                switch (PeekToken()) {
+                    // Function call
+                    case SymbolToken s when s.Symbol == "(":
+                        Expecting<SymbolToken>(t => t.Symbol == "(");
+                        // TODO: Parameter lists
+                        Expecting<SymbolToken>(t => t.Symbol == ")");
+                        Expecting<SymbolToken>(t => t.Symbol == ";");
+
+                        return new FunctionCallNode(identifierToken.Content);
+                    // Variable declaration
+                    case IdentifierToken _:
+                        Console.WriteLine("Declaration! :)");
+                        // We assume that identifierToken is now a type
+                        string variableType = identifierToken.Content;
+                        var variableIdentifier = Expecting<IdentifierToken>().Content;
+                        
+                        // If we have a default value, set it up
+                        if (PeekIgnoreMatch<SymbolToken>(s => s.Symbol == "=")) {
+                            ExpressionNode initialVal = ParseExpression();
+                            Expecting<SymbolToken>(t => t.Symbol == ";");
+                            return new DeclarationStatementNode(variableType, variableIdentifier, initialVal);
+                        }
+
+                        Expecting<SymbolToken>(t => t.Symbol == ";");
+                        return new DeclarationStatementNode(variableType, variableIdentifier);
+                    // Variable assignment
+                    case SymbolToken s when s.Symbol == "=":
+                        throw new NotImplementedException("Variable assignment without declaration isn't supported yet");
                 }
             }
 
@@ -195,15 +219,28 @@ namespace ScriptCompiler.Parsing {
 
             if (token is T tToken) {
                 if (predicate != null && !predicate(tToken)) {
-                    token.Throw($"Token '{token}' did not satisfy expected condition");
+                    throw token.CreateException($"Token '{token}' did not satisfy expected condition");
                 }
 
                 return tToken;
-            } else {
-                token.Throw($"Unexpected token '{token}' (expecting {typeof(T)})");
             }
 
-            return null;
+            throw token.CreateException($"Unexpected token '{token}' (expecting {typeof(T)})");
+        }
+
+        /// <summary>
+        /// Similar to PeekMatch, but skips the token if the check was successful. This is useful for syntax which
+        /// exists only for redirecting parsing, but has no importance of its own - for example, all that matters about
+        /// an equals sign in an assignment is that it is matched; the matched value of "=" is no longer useful after
+        /// the conditional has succeeded.
+        /// </summary>
+        private bool PeekIgnoreMatch<T>(Func<T, bool> predicate) where T : class {
+            if (PeekMatch<T>(predicate)) {
+                NextToken();
+                return true;
+            }
+
+            return false;
         }
 
         private bool PeekMatch<T>(Func<T, bool> predicate) where T : class {

--- a/ScriptCompiler/Types/ReferenceType.cs
+++ b/ScriptCompiler/Types/ReferenceType.cs
@@ -1,12 +1,12 @@
 ﻿namespace ScriptCompiler.Types {
-    public class ArrayType : SType {
+    public class ReferenceType : SType {
         public readonly SType ContainedType;
         
-        public ArrayType(SType containedType) {
+        public ReferenceType(SType containedType) {
             ContainedType = containedType;
         }
 
-        protected bool Equals(ArrayType other) {
+        protected bool Equals(ReferenceType other) {
             return Equals(ContainedType, other.ContainedType);
         }
 
@@ -14,7 +14,7 @@
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != this.GetType()) return false;
-            return Equals((ArrayType) obj);
+            return Equals((ReferenceType) obj);
         }
 
         public override int GetHashCode() {

--- a/ScriptCompiler/Types/SType.cs
+++ b/ScriptCompiler/Types/SType.cs
@@ -1,8 +1,12 @@
 ﻿namespace ScriptCompiler.Types {
     public class SType {
+        public static readonly SType SNoType = new SType();
         public static readonly SType SInteger = new SType();
         public static readonly SType SChar = new SType();
-        public static readonly SType SString = new ArrayType(SChar);
+        public static readonly SType SString = new ReferenceType(SChar);
+
+        // Most types are one (32 bit) word long
+        public readonly int Length = 1;
         
         // Do reference equality on basic types; more complicated types will do more complicated forms of equality
         public override bool Equals(object obj) {

--- a/ScriptCompiler/Types/SType.cs
+++ b/ScriptCompiler/Types/SType.cs
@@ -18,5 +18,21 @@
         public override int GetHashCode() {
             throw new System.NotImplementedException();
         }
+
+        /// <summary>
+        /// Returns a type from a type string (e.g. from 'int x = 5;'), returning SNoType if no type could be decided on
+        /// </summary>
+        public static SType FromTypeString(string nodeTypeString) {
+            switch (nodeTypeString) {
+                case "int":
+                    return SInteger;
+                case "char":
+                    return SChar;
+                case "string":
+                    return SString;
+            }
+
+            return SNoType;
+        }
     }
 }

--- a/ScriptCompiler/Visitors/CodeGenVisitor.cs
+++ b/ScriptCompiler/Visitors/CodeGenVisitor.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.CodeDom;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Design;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using ScriptCompiler.AST;
 using ScriptCompiler.AST.Statements;
@@ -74,8 +76,40 @@ namespace ScriptCompiler.Visitors {
         public string Visit(DeclarationStatementNode node) {
             var declarationBuilder = new StringBuilder();
 
+            if (_stackFrame.ExistsLocalScope(node.Identifier)) {
+                // TODO: Add line and col numbers (as well as other debug info) to all nodes, and report correctly here
+                throw new CompileException($"Attempt to redefine identifier {node.Identifier}", 0, 0);
+            }
 
-
+            SType type = SType.FromTypeString(node.TypeString);
+            if (type == SType.SNoType) {
+                throw new CompileException($"Unable to discern type from {node.TypeString}", 0, 0);
+            }
+            
+            _stackFrame.AddIdentifier(type, node.Identifier);
+            // Adjust stack pointer
+            declarationBuilder.AppendLine($"ADD r1 {type.Length}");
+            
+            // Set up with default value, if any
+            if (node.InitialValue != null) {
+                var (commands, resultReg) = new ExpressionGenVisitor(this).VisitDynamic(node.InitialValue);
+                commands.ForEach(s => declarationBuilder.AppendLine(s));
+                using (resultReg) {
+                    // Put the memory location of our variable into a free register
+                    using (var locationReg = GetRegister()) {
+                        // reg = Stack
+                        declarationBuilder.AppendLine($"MOV {locationReg} r1");
+                        
+                        // reg = Stack - offset to variable
+                        var offset = _stackFrame.Lookup(node.Identifier).position;
+                        declarationBuilder.AppendLine($"ADD {locationReg} {offset}");
+                        
+                        // Write to memory
+                        declarationBuilder.AppendLine($"MEMWRITE {locationReg} {resultReg}");
+                    }
+                }
+            }
+            
             return declarationBuilder.ToString();
         }
 

--- a/ScriptCompiler/Visitors/CodeGenVisitor.cs
+++ b/ScriptCompiler/Visitors/CodeGenVisitor.cs
@@ -71,6 +71,14 @@ namespace ScriptCompiler.Visitors {
             return functionCallBuilder.ToString();
         }
 
+        public string Visit(DeclarationStatementNode node) {
+            var declarationBuilder = new StringBuilder();
+
+
+
+            return declarationBuilder.ToString();
+        }
+
         public string Visit(PrintStatementNode node) {
             var (commands, register) = new ExpressionGenVisitor(this).VisitDynamic(node.Expression);
 

--- a/ScriptCompiler/Visitors/ExpressionGenVisitor.cs
+++ b/ScriptCompiler/Visitors/ExpressionGenVisitor.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Text;
 using ScriptCompiler.AST;
+using ScriptCompiler.AST.Statements.Expressions;
+using ScriptCompiler.AST.Statements.Expressions.Arithmetic;
+using ScriptCompiler.CompileUtil;
 
 namespace ScriptCompiler.Visitors {
     // TODO: Abstraction over string
@@ -25,14 +28,14 @@ namespace ScriptCompiler.Visitors {
 
         public (List<string>, Register) Visit(StringLiteralNode node) {
             // TODO: node.Throw()
-            if (!_codeGenVisitor.StringAliases.ContainsKey(node.String)) {
+            if (!_codeGenVisitor.StringLiteralAliases.ContainsKey(node.String)) {
                 throw new ArgumentException();
             }
 
             List<string> commands = new List<string>();
             // Put a pointer to the string into a register
             var register = _codeGenVisitor.GetRegister();
-            commands.Add($"MOV {register} !{_codeGenVisitor.StringAliases[node.String]}");
+            commands.Add($"MOV {register} !{_codeGenVisitor.StringLiteralAliases[node.String]}");
             
             return (commands, register);
         }

--- a/ScriptCompiler/Visitors/ExpressionGenVisitor.cs
+++ b/ScriptCompiler/Visitors/ExpressionGenVisitor.cs
@@ -40,6 +40,23 @@ namespace ScriptCompiler.Visitors {
             return (commands, register);
         }
 
+        public (List<string>, Register) Visit(VariableAccessNode node) {
+            List<string> instructions = new List<string>();
+            var register = _codeGenVisitor.GetRegister();
+            
+            // reg = Stack
+            instructions.Add($"MOV {register} r1");
+            
+            // reg = Stack - offset to variable
+            var offset = _codeGenVisitor.StackFrame.Lookup(node.Identifier).position;
+            instructions.Add($"ADD {register} {offset}");
+            
+            // Read from memory into the same register as we are using
+            instructions.Add($"MEMREAD {register} {register}");
+            
+            return (instructions, register);
+        }
+
         public (List<string>, Register) Visit(IntegerLiteralNode node) {
             var register = _codeGenVisitor.GetRegister();
             return (new List<string>() { $"MOV {register} {node.value}" }, register);

--- a/ScriptCompiler/Visitors/IRegisterAllocator.cs
+++ b/ScriptCompiler/Visitors/IRegisterAllocator.cs
@@ -1,4 +1,6 @@
-﻿namespace ScriptCompiler.Visitors {
+﻿using ScriptCompiler.CompileUtil;
+
+namespace ScriptCompiler.Visitors {
     public interface IRegisterAllocator {
         Register GetRegister();
     }

--- a/ScriptCompiler/Visitors/StringLiteralCollectorVisitor.cs
+++ b/ScriptCompiler/Visitors/StringLiteralCollectorVisitor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using ScriptCompiler.AST;
+using ScriptCompiler.AST.Statements.Expressions;
 
 namespace ScriptCompiler.Visitors {
     public class StringLiteralCollectorVisitor : EverythingVisitor<List<string>> {

--- a/ScriptCompiler/Visitors/TypeDeterminationVisitor.cs
+++ b/ScriptCompiler/Visitors/TypeDeterminationVisitor.cs
@@ -5,12 +5,23 @@ using ScriptCompiler.Types;
 
 namespace ScriptCompiler.Visitors {
     public class TypeDeterminationVisitor : Visitor<SType> {
+        private readonly CodeGenVisitor _codeGenVisitor;
+        
+        public TypeDeterminationVisitor(CodeGenVisitor codeGenVisitor) {
+            _codeGenVisitor = codeGenVisitor;
+        }
+
         public override SType Visit(ASTNode node) {
             throw new NotImplementedException(node.GetType().FullName);
         }
-
+        
         public SType VisitDynamic(ASTNode node) {
             return this.Visit(node as dynamic);
+        }
+
+        public SType Visit(VariableAccessNode node) {
+            var (type, _) = _codeGenVisitor.StackFrame.Lookup(node.Identifier);
+            return type;
         }
 
         public SType Visit(IntegerLiteralNode _) {

--- a/ScriptCompiler/Visitors/TypeDeterminationVisitor.cs
+++ b/ScriptCompiler/Visitors/TypeDeterminationVisitor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using ScriptCompiler.AST;
+using ScriptCompiler.AST.Statements.Expressions;
 using ScriptCompiler.Types;
 
 namespace ScriptCompiler.Visitors {

--- a/ScriptCompiler/test.sscript
+++ b/ScriptCompiler/test.sscript
@@ -1,3 +1,4 @@
+int x = 5;
 print "Hello, world";
 
 function void testt() {

--- a/ScriptCompiler/test.sscript
+++ b/ScriptCompiler/test.sscript
@@ -1,5 +1,7 @@
 int x = 5;
 int y;
+int z = 6;
+print x + z + y;
 print "Hello, world";
 
 function void testt() {

--- a/ScriptCompiler/test.sscript
+++ b/ScriptCompiler/test.sscript
@@ -1,4 +1,5 @@
 int x = 5;
+int y;
 print "Hello, world";
 
 function void testt() {

--- a/ScriptCompilerTests/StringLiteralCollectorVisitorTest.cs
+++ b/ScriptCompilerTests/StringLiteralCollectorVisitorTest.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using ScriptCompiler;
 using ScriptCompiler.AST;
+using ScriptCompiler.AST.Statements;
+using ScriptCompiler.AST.Statements.Expressions;
 using ScriptCompiler.Visitors;
 using Xunit;
 

--- a/ShaRPG/VM/ScriptVM.cs
+++ b/ShaRPG/VM/ScriptVM.cs
@@ -13,6 +13,7 @@ namespace ShaRPG.VM {
     // Bytecode VM for a small language. 32-bit integers are the smallest atomic unit.
     public class ScriptVM {
         private const int InstructionRegister = 0;
+        private const int StackPointerRegister = 1;
         private readonly List<int> _bytes;
         private readonly Dictionary<int, int> _registers;
         private readonly Flags _flagRegister;
@@ -41,8 +42,10 @@ namespace ShaRPG.VM {
             instructionPages.ForEach(x => x.Lock());
             
             _registers = new Dictionary<int, int> {
-                [InstructionRegister] = bytes[0]
+                [InstructionRegister] = bytes[0],
+                [StackPointerRegister] = instructionPages.Count * MemoryPage.PageSize
             };
+            
             _flagRegister = new Flags();
             _stack = new Stack<int>();
         }
@@ -141,6 +144,12 @@ namespace ShaRPG.VM {
                     break;
                 case Instruction.PrintInt:
                     PrintMethod(PopStack().ToString());
+                    break;
+                case Instruction.MemWrite:
+                    var val = PopStack();
+                    var pos = PopStack();
+                    Console.WriteLine($"Writing mem[{pos}]={val}");
+                    WriteMemory(pos, val);
                     break;
                 default:
                     PrintMethod("Unexpected instruction");
@@ -242,6 +251,8 @@ namespace ShaRPG.VM {
             JmpLTE,
             Print,
             PrintInt,
+            MemWrite,
+            MemRead,
         }
 
         private class Flags {

--- a/ShaRPG/VM/ScriptVM.cs
+++ b/ShaRPG/VM/ScriptVM.cs
@@ -151,6 +151,11 @@ namespace ShaRPG.VM {
                     Console.WriteLine($"Writing mem[{pos}]={val}");
                     WriteMemory(pos, val);
                     break;
+                case Instruction.MemRead:
+                    var loc = PopStack();
+                    Console.WriteLine($"Reading mem[{loc}]");
+                    _stack.Push(ReadMemory(loc));
+                    break;
                 default:
                     PrintMethod("Unexpected instruction");
                     break;


### PR DESCRIPTION
This change:

* Adds MEMREAD and MEMWRITE instructions to the VM and assembler
* Reserves register 1 as the stack pointer, which is initialised to a sensible value by the VM during initialization
* Adds stack frame understanding to the compiler (though currently only a single stack frame is ever used, scoping should be easily supported with a future change)
* Now parses assignment declarations and variable accesses
* Generates assembly code for the above
* Updates the test script to demonstrate this functionality
* Tidies up the AST class hierarchy so it's not a single folder full of dozens of classes
* Adds string -> type functionality (e.g. "int" -> SInteger)
* Various improvements