### PR TITLE
Major optimisations to the scripting language

### DIFF
--- a/ScriptCompiler/CodeGeneration/Assembly/Instructions/AddInstruction.cs
+++ b/ScriptCompiler/CodeGeneration/Assembly/Instructions/AddInstruction.cs
@@ -1,15 +1,13 @@
 namespace ScriptCompiler.CodeGeneration.Assembly.Instructions {
-    public class AddInstruction : Instruction {
-        private readonly Location _toLocation;
-        private readonly Value _value;
-
-        public AddInstruction(Location toLocation, Value value) {
-            _toLocation = toLocation;
-            _value     = value;
-        }
+    public class AddInstruction : BinaryArithmeticInstruction {
+        public AddInstruction(Location toLocation, Value value) : base(toLocation, value) { } 
 
         protected override string AsString() {
-            return $"ADD {_toLocation} {_value}";
+            return $"ADD {ToLocation} {Value}";
+        }
+
+        public override bool IsNoop() {
+            return Value is NumericConstant nc && nc == 0;
         }
     }
 }

--- a/ScriptCompiler/CodeGeneration/Assembly/Instructions/BinaryArithmeticInstruction.cs
+++ b/ScriptCompiler/CodeGeneration/Assembly/Instructions/BinaryArithmeticInstruction.cs
@@ -1,7 +1,3 @@
-using System.Net.Http.Headers;
-using Microsoft.VisualBasic;
-using ScriptCompiler.Parsing;
-
 namespace ScriptCompiler.CodeGeneration.Assembly.Instructions {
     public abstract class BinaryArithmeticInstruction : Instruction {
         public readonly Value Value;

--- a/ScriptCompiler/CodeGeneration/Assembly/Instructions/BinaryArithmeticInstruction.cs
+++ b/ScriptCompiler/CodeGeneration/Assembly/Instructions/BinaryArithmeticInstruction.cs
@@ -1,0 +1,68 @@
+using System.Net.Http.Headers;
+using Microsoft.VisualBasic;
+using ScriptCompiler.Parsing;
+
+namespace ScriptCompiler.CodeGeneration.Assembly.Instructions {
+    public abstract class BinaryArithmeticInstruction : Instruction {
+        public readonly Value Value;
+        protected readonly Location ToLocation;
+
+        public BinaryArithmeticInstruction(Location toLocation, Value value) {
+            ToLocation = toLocation;
+            Value      = value;
+        }
+
+        public bool SameLocation(BinaryArithmeticInstruction other) {
+            return ToLocation == other.ToLocation;
+        }
+
+        public abstract bool IsNoop();
+
+        // TODO Polymorphism
+        public bool TryCombine(Instruction other, out BinaryArithmeticInstruction result) {
+            if (!(other is BinaryArithmeticInstruction otherArithmetic && SameLocation(otherArithmetic) &&
+                  Value is NumericConstant ncLeft &&
+                  otherArithmetic.Value is NumericConstant ncRight)) {
+                result = null;
+                return false;
+            }
+
+            if (this is AddInstruction) {
+                switch (other) {
+                    case AddInstruction _:
+                        result = new AddInstruction(ToLocation, ncLeft + ncRight);
+                        return true;
+                    case SubInstruction _:
+                        var subResult = ncLeft - ncRight;
+                        if (subResult >= 0) {
+                            result = new AddInstruction(ToLocation, subResult);
+                        } else {
+                            result = new SubInstruction(ToLocation, -subResult);
+                        }
+
+                        return true;
+                }
+            }
+            
+            if (this is SubInstruction) {
+                switch (other) {
+                    case AddInstruction _:
+                        var addResult = ncLeft - ncRight;
+                        if (addResult >= 0) {
+                            result = new SubInstruction(ToLocation, addResult);
+                        } else {
+                            result = new AddInstruction(ToLocation, -addResult);
+                        }
+                        return true;
+                    case SubInstruction _:
+                        result = new SubInstruction(ToLocation, ncLeft + ncRight);
+                        return true;
+                }
+            }
+            
+            // TODO: Optimisations for mul and div
+            result = null;
+            return false;
+        }
+    }
+}

--- a/ScriptCompiler/CodeGeneration/Assembly/Instructions/DivInstruction.cs
+++ b/ScriptCompiler/CodeGeneration/Assembly/Instructions/DivInstruction.cs
@@ -1,15 +1,13 @@
 namespace ScriptCompiler.CodeGeneration.Assembly.Instructions {
-    public class DivInstruction : Instruction {
-        private readonly Location _toLocation;
-        private readonly Value _value;
-
-        public DivInstruction(Location toLocation, Value value) {
-            _toLocation = toLocation;
-            _value     = value;
-        }
+    public class DivInstruction : BinaryArithmeticInstruction {
+        public DivInstruction(Location toLocation, Value value) : base(toLocation, value) { }
 
         protected override string AsString() {
-            return $"DIV {_toLocation} {_value}";
+            return $"DIV {ToLocation} {Value}";
+        }
+
+        public override bool IsNoop() {
+            return Value is NumericConstant nc && nc == 1;
         }
     }
 }

--- a/ScriptCompiler/CodeGeneration/Assembly/Instructions/MulInstruction.cs
+++ b/ScriptCompiler/CodeGeneration/Assembly/Instructions/MulInstruction.cs
@@ -1,15 +1,13 @@
 namespace ScriptCompiler.CodeGeneration.Assembly.Instructions {
-    public class MulInstruction : Instruction {
-        private readonly Location _toLocation;
-        private readonly Value _value;
-
-        public MulInstruction(Location toLocation, Value value) {
-            _toLocation = toLocation;
-            _value     = value;
-        }
+    public class MulInstruction : BinaryArithmeticInstruction {
+        public MulInstruction(Location toLocation, Value value) : base(toLocation, value) { }
 
         protected override string AsString() {
-            return $"MUL {_toLocation} {_value}";
+            return $"MUL {ToLocation} {Value}";
+        }
+
+        public override bool IsNoop() {
+            return Value is NumericConstant nc && nc == 1;
         }
     }
 }

--- a/ScriptCompiler/CodeGeneration/Assembly/Instructions/SubInstruction.cs
+++ b/ScriptCompiler/CodeGeneration/Assembly/Instructions/SubInstruction.cs
@@ -1,15 +1,13 @@
 namespace ScriptCompiler.CodeGeneration.Assembly.Instructions {
-    public class SubInstruction : Instruction {
-        private readonly Location _fromLocation;
-        private readonly Value _amount;
-
-        public SubInstruction(Location toLocation, Value amount) {
-            _fromLocation = toLocation;
-            _amount       = amount;
-        }
+    public class SubInstruction : BinaryArithmeticInstruction {
+        public SubInstruction(Location toLocation, Value amount) : base(toLocation, amount) { }
 
         protected override string AsString() {
-            return $"SUB {_fromLocation} {_amount}";
+            return $"SUB {ToLocation} {Value}";
+        }
+
+        public override bool IsNoop() {
+            return Value is NumericConstant nc && nc == 0;
         }
     }
 }

--- a/ScriptCompiler/CodeGeneration/Assembly/NumericConstant.cs
+++ b/ScriptCompiler/CodeGeneration/Assembly/NumericConstant.cs
@@ -1,13 +1,17 @@
 namespace ScriptCompiler.CodeGeneration.Assembly {
     public class NumericConstant : Value {
-        private readonly int _amount;
+        public readonly int Amount;
 
         public NumericConstant(int amount) {
-            _amount = amount;
+            Amount = amount;
         }
 
         public override string ToString() {
-            return $"{_amount}";
+            return $"{Amount}";
+        }
+        
+        public static implicit operator int(NumericConstant nc) {
+            return nc.Amount;
         }
     }
 }

--- a/ScriptCompiler/CodeGeneration/Optimiser.cs
+++ b/ScriptCompiler/CodeGeneration/Optimiser.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using ScriptCompiler.CodeGeneration.Assembly;
+using ScriptCompiler.CodeGeneration.Assembly.Instructions;
+
+namespace ScriptCompiler.CodeGeneration {
+    public class Optimiser {
+        public static List<Instruction> Optimise(List<Instruction> instructions) {
+            // Combine arithmetic
+            int i = 0;
+            while (i < instructions.Count) {
+                while (i + 1 < instructions.Count) {
+                    if (instructions[i] is BinaryArithmeticInstruction left) {
+                        if (left.TryCombine(instructions[i + 1], out var result)) {
+                            Console.WriteLine($"Combining {instructions[i]} with {instructions[i + 1]}");
+                            instructions[i] = result;
+                            Console.WriteLine($"Combined to {instructions[i]}");
+                            instructions.RemoveAt(i + 1);
+                            continue;
+                        }
+                    }
+
+                    break;
+                }
+
+                if (instructions[i] is BinaryArithmeticInstruction num && num.IsNoop()) {
+                    instructions.RemoveAt(i);
+                    continue;
+                }
+                i++;
+            }
+
+            return instructions;
+        }
+    }
+}

--- a/ScriptCompiler/MainClass.cs
+++ b/ScriptCompiler/MainClass.cs
@@ -20,7 +20,7 @@ namespace ScriptCompiler {
                 Console.WriteLine("Enter the path to the file to compile/assemble");
                 fileName = Console.ReadLine();
             }
-            
+
             if (args[0] == "compile") {
                 Console.WriteLine(Parser.FromFile(fileName).Compile());
             } else if (args[0] == "assemble") {
@@ -31,28 +31,43 @@ namespace ScriptCompiler {
 
                 string bytecodeString = string.Join(",", compiled);
                 Console.WriteLine($"{compiled.Count} words in total");
-                
+
                 Console.WriteLine(bytecodeString);
-                
+
                 List<int> bytecode = bytecodeString.Split(',').Select(int.Parse).ToList();
 
                 ScriptVM scriptVm = new ScriptVM(bytecode);
                 scriptVm.Execute();
+            } else if (args[0] == "compile-assemble") {
+                var compiled = Parser.FromFile(fileName).Compile();
+                Console.WriteLine("Compiled code:");
+                Console.WriteLine(compiled);
+
+                var assembled =
+                    new Assembler(compiled.Split(new[] {Environment.NewLine}, StringSplitOptions.None).ToList())
+                        .Compile();
+                string bytecodeString = string.Join(",", assembled);
+
+                Console.WriteLine("Assembled code:");
+                Console.WriteLine(bytecodeString);
+                Console.WriteLine($"{assembled.Count} words in total");
             } else if (args[0] == "execute") {
                 var compiled = Parser.FromFile(fileName).Compile();
                 Console.WriteLine("Compiled code:");
                 Console.WriteLine(compiled);
 
-                var assembled = new Assembler(compiled.Split(new []{ Environment.NewLine }, StringSplitOptions.None).ToList()).Compile();
+                var assembled =
+                    new Assembler(compiled.Split(new[] {Environment.NewLine}, StringSplitOptions.None).ToList())
+                        .Compile();
                 string bytecodeString = string.Join(",", assembled);
-                
+
                 Console.WriteLine("Assembled code:");
                 Console.WriteLine(bytecodeString);
                 Console.WriteLine($"{assembled.Count} words in total");
 
                 List<int> bytecode = bytecodeString.Split(',').Select(int.Parse).ToList();
                 new ScriptVM(bytecode).Execute();
-            }else {
+            } else {
                 Console.WriteLine($"Unexpected argument {args[0]}");
             }
         }

--- a/ScriptCompiler/test.fscr
+++ b/ScriptCompiler/test.fscr
@@ -1,5 +1,16 @@
-func int testA() {
-    return 5;
+struct Player {
+    int health;
+    int mana;
 }
 
-print testA() + testA() + testA() + testA() * testA();
+Player a;
+Player b;
+
+print a.health = 10;
+print a.mana = 20;
+print b.health = 30;
+b = a;
+print a.health;
+print a.mana;
+print b.health;
+print b.mana;


### PR DESCRIPTION
This results in a 25% reduction in the `test_old.fscr` bytecode, and presumably even more in arithmetic heavy code.