### PR TITLE
Migrate to using uint for integer literals and addressing

### DIFF
--- a/ForgottenRPG/VM/IMemoryPage.cs
+++ b/ForgottenRPG/VM/IMemoryPage.cs
@@ -1,6 +1,6 @@
 ﻿namespace ForgottenRPG.VM {
     public interface IMemoryPage {
-        int ReadAddress(int offset);
-        void WriteAddress(int offset, int value);
+        int ReadAddress(uint offset);
+        void WriteAddress(uint offset, int value);
     }
 }

--- a/ForgottenRPG/VM/MemoryPage.cs
+++ b/ForgottenRPG/VM/MemoryPage.cs
@@ -1,16 +1,16 @@
 ﻿namespace ForgottenRPG.VM {
     public class MemoryPage : IMemoryPage {
         // 16 kB pages - 4096 32-bit integers per page
-        public const int PageSize = 1024 * 4;
+        public const uint PageSize = 1024 * 4;
         
         private readonly int[] _memory = new int[PageSize];
         private bool _locked = false;
         
-        public int ReadAddress(int offset) {
+        public int ReadAddress(uint offset) {
             return _memory[offset];
         }
 
-        public void WriteAddress(int offset, int value) {
+        public void WriteAddress(uint offset, int value) {
             if (_locked) throw new IllegalMemoryAccessException("Attempt to write to protected page");
             _memory[offset] = value;
         }

--- a/ScriptCompiler/AST/Statements/Expressions/IntegerLiteralNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/IntegerLiteralNode.cs
@@ -1,9 +1,9 @@
 ﻿namespace ScriptCompiler.AST.Statements.Expressions {
     public class IntegerLiteralNode : NumericLiteralNode {
-        public readonly int Value;
+        public readonly uint Value;
 
-        public IntegerLiteralNode(int value) {
-            this.Value = value;
+        public IntegerLiteralNode(uint value) {
+            Value = value;
         }
     }
 }

--- a/ScriptCompiler/CodeGeneration/ExpressionGenerator.cs
+++ b/ScriptCompiler/CodeGeneration/ExpressionGenerator.cs
@@ -136,7 +136,7 @@ namespace ScriptCompiler.CodeGeneration {
 
         public List<Instruction> Visit(IntegerLiteralNode node) {
             return new List<Instruction> {
-                new MemWriteInstruction(StackPointer, node.Value),
+                new MemWriteInstruction(StackPointer, (int) node.Value),
                 PushStack(SType.SInteger)
             };
         }

--- a/ScriptCompiler/Parsing/Lexer.cs
+++ b/ScriptCompiler/Parsing/Lexer.cs
@@ -125,7 +125,7 @@ namespace ScriptCompiler.Parsing {
         private LexToken LexNumber() {
             return new IntegerToken(_scanLine,
                                     _scanPosition,
-                                    int.Parse(TakeUntil(c => !IsNumber(c)).str));
+                                    uint.Parse(TakeUntil(c => !IsNumber(c)).str));
         }
 
         private (string str, bool terminated) TakeUntil(Predicate<char> condition) {
@@ -235,9 +235,9 @@ namespace ScriptCompiler.Parsing {
     }
 
     public class IntegerToken : LexToken {
-        public readonly int Content;
+        public readonly uint Content;
 
-        public IntegerToken(int line, int position, int content) : base(line, position) {
+        public IntegerToken(int line, int position, uint content) : base(line, position) {
             Content = content;
         }
 

--- a/ScriptCompiler/mem.fscr
+++ b/ScriptCompiler/mem.fscr
@@ -1,0 +1,8 @@
+func int @malloc(int size) {
+    int @mallocBase = 2147483648;
+    
+    // TODO: We need conditionals and arbitrary pointer arithmetic before we can proceed...
+    return mallocBase;
+    }
+
+print !malloc(5);


### PR DESCRIPTION
This hacky PR switches the parser, code generator, and VM to use uints for integer literals (casting back and forth bitwise so that they're treated consistently in a typed context), and has the VM access memory using uints so that the addressable virtual memory space is now 4GB instead of 2GB. It also adds `mem.fscr`, which I anticipate will morph into the base of the dynamic memory allocation system, and potentially in the future, if it seems helpful, a run-time garbage collector module 😄 