### PR TITLE
Major bugfixes and start of Constexpr support

### DIFF
--- a/ForgottenRPG/Map/GameMap.cs
+++ b/ForgottenRPG/Map/GameMap.cs
@@ -114,6 +114,7 @@ namespace ForgottenRPG.Map {
         }
 
         // TODO: Identify a number of candidate positions and choose the best (closest) so we can increase density
+        // Coming back just over a year later, this code is delightfully hacky given how well it actually works
         private void TryDropItem(GameCoordinate position, ItemStack item, int retries = 25) {
             if (retries == 0 || !_items.Any(i => i.position.EuclideanDistance(position) < 16)) {
                 _items.Add((item, position));
@@ -129,7 +130,7 @@ namespace ForgottenRPG.Map {
         }
     }
 
-    public struct GameMapEntitySpawnDetails {
+    public readonly struct GameMapEntitySpawnDetails {
         public readonly TileCoordinate Position;
         public readonly string EntityName;
         public readonly List<TileCoordinate> Path;

--- a/ForgottenRPG/VM/ScriptVM.cs
+++ b/ForgottenRPG/VM/ScriptVM.cs
@@ -13,7 +13,7 @@ namespace ForgottenRPG.VM {
         private readonly Stack<int> _stack;
         private readonly Dictionary<uint, IMemoryPage> _memory = new Dictionary<uint, IMemoryPage>();
         private readonly uint _stackPointerBase;
-        private uint _maxExecutionAddress;
+        private readonly uint _maxExecutionAddress;
         public Action<string> PrintMethod { get; set; } = s => ServiceLocator.LogService.Log(LogType.Info, "VM : " + s);
 
         public ScriptVm(List<int> bytes) {

--- a/ScriptCompiler/AST/Statements/Expressions/IConstExpr.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/IConstExpr.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+namespace ScriptCompiler.AST.Statements.Expressions {
+    public interface IConstExpr {
+        public uint[]? Calculate();
+
+        protected uint[]? CalcOne(IConstExpr child, Func<uint[], uint[]?> calc) {
+            var result = child.Calculate();
+            return result != null ? calc(result) : null;
+        }
+
+        protected uint[]? CalcTwo(IConstExpr child, Func<uint[], uint[], uint[]?> calc) {
+            var result1 = child.Calculate();
+            var result2 = child.Calculate();
+            return (result1 != null && result2 != null) ? calc(result1, result2) : null;
+        }
+
+        protected uint[]? CalcThree(IConstExpr child, Func<uint[], uint[], uint[], uint[]?> calc) {
+            var result1 = child.Calculate();
+            var result2 = child.Calculate();
+            var result3 = child.Calculate();
+            return (result1 != null && result2 != null && result3 != null) ? calc(result1, result2, result3) : null;
+        }
+    }
+}

--- a/ScriptCompiler/AST/Statements/Expressions/IntegerLiteralNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/IntegerLiteralNode.cs
@@ -1,9 +1,15 @@
-﻿namespace ScriptCompiler.AST.Statements.Expressions {
-    public class IntegerLiteralNode : NumericLiteralNode {
+﻿using System.Collections.Generic;
+
+namespace ScriptCompiler.AST.Statements.Expressions {
+    public class IntegerLiteralNode : NumericLiteralNode, IConstExpr {
         public readonly uint Value;
 
         public IntegerLiteralNode(uint value) {
             Value = value;
+        }
+
+        public uint[] Calculate() {
+            return new[]{Value};
         }
     }
 }

--- a/ScriptCompiler/Assembler.cs
+++ b/ScriptCompiler/Assembler.cs
@@ -115,8 +115,8 @@ namespace ScriptCompiler {
                     // The value is stored as a comma-separated int array
                     // e.g. STATIC $stc_... 0,0,0,0 => $stc_... = 0,0,0,0
                     List<int> initialValue = components[2].Split(",").Select(int.Parse).ToList();
-                    _userData.AddRange(initialValue);
                     _userDataIndexes[components[1]] = _userData.Count + UserDataOffset;
+                    _userData.AddRange(initialValue);
                     break;
             }
         }

--- a/ScriptCompiler/CodeGeneration/Assembly/Instructions/StaticInstruction.cs
+++ b/ScriptCompiler/CodeGeneration/Assembly/Instructions/StaticInstruction.cs
@@ -5,9 +5,9 @@ using System.Text;
 namespace ScriptCompiler.CodeGeneration.Assembly.Instructions {
     public class StaticInstruction : Instruction {
         private readonly StaticLabel _label;
-        private readonly int[] _initial;
+        private readonly uint[] _initial;
         
-        public StaticInstruction(StaticLabel label, int[] initial) {
+        public StaticInstruction(StaticLabel label, uint[] initial) {
             _label = label;
             _initial = initial;
         }

--- a/ScriptCompiler/CodeGeneration/StaticVariableRepository.cs
+++ b/ScriptCompiler/CodeGeneration/StaticVariableRepository.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 
 namespace ScriptCompiler.CodeGeneration {
     internal class StaticVariableRepository {
-        public readonly Dictionary<Guid, int[]> Values = new Dictionary<Guid, int[]>();
+        public readonly Dictionary<Guid, uint[]> Values = new Dictionary<Guid, uint[]>();
         
-        public Guid CreateNew(int[] initialValue) {
+        public Guid CreateNew(uint[] initialValue) {
             var guid = Guid.NewGuid();
             Values[guid] = initialValue;
             return guid;

--- a/ScriptCompiler/test.fscr
+++ b/ScriptCompiler/test.fscr
@@ -1,25 +1,9 @@
-struct test {
-    int x;
-    int y;
-    int z;
-    string m;
-}
-
-func void test(int n) {
-    static int test_old;
-    static int test;
-    
-    if test_old == 0 {
-        test_old = 1;
-        test = 1;
+for int i = 0; i < 2; i = i + 1 {
+    for int j = 0; j < 2; j = j + 1 {
+        for int k = 0; k < 2; k = k + 1 {
+            print i;
+            print j;
+            print k;
+        }
     }
-    
-    print test;
-    int curr_test = test;
-    test = test + test_old;
-    test_old = curr_test;
-}
-
-for int i = 0; i < 10; i = i + 1 {
-    test(42);
 }

--- a/ScriptCompilerTests/IntegrationTests.cs
+++ b/ScriptCompilerTests/IntegrationTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using ScriptCompiler;
 using ScriptCompiler.Parsing;
 using ForgottenRPG.VM;
+using Microsoft.VisualBasic;
 using NUnit.Framework;
 using Xunit;
 using Assert = Xunit.Assert;
@@ -228,6 +229,18 @@ print b.mana;");
                 }
             }
             CollectionAssert.AreEqual(expected, _output);
+        }
+
+        [Fact]
+        public void CanDoLoopsWithVariablesWithin() {
+            ExecuteCode("for int i = 0; i < 3; i = i + 1 { int k = 5; print k + i; }");
+            CollectionAssert.AreEqual(new List<string>{"5", "6", "7"}, _output);
+        }
+
+        [Fact]
+        public void CanDoStaticVariables() {
+            ExecuteCode("func void iter() { static int x = 0; print (x = x + 1); } iter(); iter(); iter();");
+            CollectionAssert.AreEqual(new List<string>{"1", "2", "3"}, _output);
         }
 
         private void ExecuteCode(string code) {


### PR DESCRIPTION
1. Major bug fixes around for loops which previously mismanaged their stack frames in a way that broke nested for loops which contained locals (those locals would have space allocated on the stack again in every iteration without popping the old ones, causing them to "become" the outer loop variable by virtue of their relative position to the stack pointer)
2. Start of constexpr support which allows expressions to optionally evaluate to a constant `uint[]` if they implement an interface. Currently this only supports integer constants, but it'll be pretty to add more.
3. By virtue of (2), also adds support for `static` variables to be initialised at define time, provided they can be evaluated as a `constexpr`. 

.. I'm beginning to worry I'm just implementing C++...