### PR TITLE
Add floats and static variable default initialisation

### DIFF
--- a/ForgottenRPG/Entity/Dialog/Dialog.cs
+++ b/ForgottenRPG/Entity/Dialog/Dialog.cs
@@ -69,7 +69,7 @@ namespace ForgottenRPG.Entity.Dialog {
                         if (string.IsNullOrEmpty(prompt)) prompt = "End discussion";
                         break;
                     case "code":
-                        replyActions.Add(new DialogActionCode(replyAction.Value.Split(',').Select(int.Parse).ToList()));
+                        replyActions.Add(new DialogActionCode(replyAction.Value.Split(',').Select(uint.Parse).ToList()));
                         break;
                 }
             }

--- a/ForgottenRPG/Entity/Dialog/DialogAction.cs
+++ b/ForgottenRPG/Entity/Dialog/DialogAction.cs
@@ -25,14 +25,14 @@ namespace ForgottenRPG.Entity.Dialog {
     }
 
     public class DialogActionCode : DialogAction {
-        private readonly List<int> _code;
+        private readonly List<uint> _code;
 
-        public DialogActionCode(List<int> code) {
+        public DialogActionCode(List<uint> code) {
             _code = code;
         }
 
         public override void Execute(Dialog dialog) {
-            new ScriptVm(new List<int>(_code)).Execute();
+            new ScriptVm(new List<uint>(_code)).Execute();
         }
     }
 }

--- a/ForgottenRPG/VM/IMemoryPage.cs
+++ b/ForgottenRPG/VM/IMemoryPage.cs
@@ -1,6 +1,6 @@
 ﻿namespace ForgottenRPG.VM {
     public interface IMemoryPage {
-        int ReadAddress(uint offset);
-        void WriteAddress(uint offset, int value);
+        uint ReadAddress(uint offset);
+        void WriteAddress(uint offset, uint value);
     }
 }

--- a/ForgottenRPG/VM/MemoryPage.cs
+++ b/ForgottenRPG/VM/MemoryPage.cs
@@ -3,14 +3,14 @@
         // 16 kB pages - 4096 32-bit integers per page
         public const uint PageSize = 1024 * 4;
         
-        private readonly int[] _memory = new int[PageSize];
+        private readonly uint[] _memory = new uint[PageSize];
         private bool _locked = false;
         
-        public int ReadAddress(uint offset) {
+        public uint ReadAddress(uint offset) {
             return _memory[offset];
         }
 
-        public void WriteAddress(uint offset, int value) {
+        public void WriteAddress(uint offset, uint value) {
             if (_locked) throw new IllegalMemoryAccessException("Attempt to write to protected page");
             _memory[offset] = value;
         }

--- a/ScriptCompiler/AST/Statements/Expressions/Arithmetic/AdditionNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/Arithmetic/AdditionNode.cs
@@ -1,7 +1,15 @@
-﻿namespace ScriptCompiler.AST.Statements.Expressions.Arithmetic {
-    public class AdditionNode : BinaryOperatorNode {
+﻿using ScriptCompiler.CodeGeneration;
+
+namespace ScriptCompiler.AST.Statements.Expressions.Arithmetic {
+    public class AdditionNode : BinaryOperatorNode, IConstExpr {
         public AdditionNode(ExpressionNode left, ExpressionNode right) : base(left, right) {
             
+        }
+
+        public override uint[]? Calculate(CalcContext ctx) {
+            return IConstExpr.CalcTwo(ctx, Left, Right, (uints, uints1) => {
+                return new[]{ uints[0] + uints1[0] };
+            });
         }
     }
 }

--- a/ScriptCompiler/AST/Statements/Expressions/Arithmetic/DivisionNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/Arithmetic/DivisionNode.cs
@@ -3,5 +3,11 @@
         public DivisionNode(ExpressionNode left, ExpressionNode right) : base(left, right) {
             
         }
+
+        public override uint[]? Calculate(CalcContext ctx) {
+            return IConstExpr.CalcTwo(ctx, Left, Right, (uints, uints1) => {
+                return new[]{ uints[0] / uints1[0] };
+            });
+        }
     }
 }

--- a/ScriptCompiler/AST/Statements/Expressions/Arithmetic/MultiplicationNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/Arithmetic/MultiplicationNode.cs
@@ -3,5 +3,11 @@
         public MultiplicationNode(ExpressionNode left, ExpressionNode right) : base(left, right) {
             
         }
+
+        public override uint[]? Calculate(CalcContext ctx) {
+            return IConstExpr.CalcTwo(ctx, Left, Right, (uints, uints1) => {
+                return new[]{ uints[0] * uints1[0] };
+            });
+        }
     }
 }

--- a/ScriptCompiler/AST/Statements/Expressions/Arithmetic/SubtractionNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/Arithmetic/SubtractionNode.cs
@@ -3,5 +3,11 @@
         public SubtractionNode(ExpressionNode left, ExpressionNode right) : base(left, right) {
             
         }
+
+        public override uint[]? Calculate(CalcContext ctx) {
+            return IConstExpr.CalcTwo(ctx, Left, Right, (uints, uints1) => {
+                return new[]{ uints[0] - uints1[0] };
+            });
+        }
     }
 }

--- a/ScriptCompiler/AST/Statements/Expressions/CalcContext.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/CalcContext.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices.ComTypes;
+using ScriptCompiler.CodeGeneration;
+using StackFrame = ScriptCompiler.CompileUtil.StackFrame;
+
+namespace ScriptCompiler.AST.Statements.Expressions {
+    // A context for evaluating a constexpr within
+    public readonly struct CalcContext {
+        // If set, the evaluation context is static (and can therefore be initialised based on other static variables)
+        public readonly bool Static;
+        private readonly StackFrame _stackFrame;
+        private readonly StaticVariableRepository _staticRepository;
+
+        public CalcContext(bool @static, StackFrame stackFrame, StaticVariableRepository staticRepository) {
+            Static           = @static;
+            _stackFrame       = stackFrame;
+            _staticRepository = staticRepository;
+        }
+
+        public uint[]? EvaluateVariable(string identifier) {
+            return _stackFrame.Lookup(identifier) is (_, null, { } guid) ? _staticRepository.Values[guid] : null;
+        }
+    }
+}

--- a/ScriptCompiler/AST/Statements/Expressions/ExpressionNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/ExpressionNode.cs
@@ -1,5 +1,7 @@
 ﻿namespace ScriptCompiler.AST.Statements.Expressions {
-    public abstract class ExpressionNode : StatementNode {
-        
+    public abstract class ExpressionNode : StatementNode, IConstExpr {
+        public virtual uint[]? Calculate(CalcContext _) {
+            return null;
+        }
     }
 }

--- a/ScriptCompiler/AST/Statements/Expressions/FloatLiteralNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/FloatLiteralNode.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ScriptCompiler.AST.Statements.Expressions {
+    public class FloatLiteralNode : NumericLiteralNode, IConstExpr {
+        public readonly float Value;
+
+        public FloatLiteralNode(float value) {
+            Value = value;
+        }
+
+        public override uint[] Calculate(CalcContext _) {
+            return new[]{(uint)BitConverter.SingleToInt32Bits(Value)};
+        }
+    }
+}

--- a/ScriptCompiler/AST/Statements/Expressions/IConstExpr.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/IConstExpr.cs
@@ -3,23 +3,23 @@ using System.Collections.Generic;
 
 namespace ScriptCompiler.AST.Statements.Expressions {
     public interface IConstExpr {
-        public uint[]? Calculate();
+        public uint[]? Calculate(CalcContext ctx);
 
-        protected uint[]? CalcOne(IConstExpr child, Func<uint[], uint[]?> calc) {
-            var result = child.Calculate();
+        public static uint[]? CalcOne(CalcContext ctx, IConstExpr child, Func<uint[], uint[]?> calc) {
+            var result = child.Calculate(ctx);
             return result != null ? calc(result) : null;
         }
 
-        protected uint[]? CalcTwo(IConstExpr child, Func<uint[], uint[], uint[]?> calc) {
-            var result1 = child.Calculate();
-            var result2 = child.Calculate();
+        public static uint[]? CalcTwo(CalcContext ctx, IConstExpr child, IConstExpr child2, Func<uint[], uint[], uint[]?> calc) {
+            var result1 = child.Calculate(ctx);
+            var result2 = child2.Calculate(ctx);
             return (result1 != null && result2 != null) ? calc(result1, result2) : null;
         }
 
-        protected uint[]? CalcThree(IConstExpr child, Func<uint[], uint[], uint[], uint[]?> calc) {
-            var result1 = child.Calculate();
-            var result2 = child.Calculate();
-            var result3 = child.Calculate();
+        public static uint[]? CalcThree(CalcContext ctx, IConstExpr child, IConstExpr child2, IConstExpr child3, Func<uint[], uint[], uint[], uint[]?> calc) {
+            var result1 = child.Calculate(ctx);
+            var result2 = child2.Calculate(ctx);
+            var result3 = child3.Calculate(ctx);
             return (result1 != null && result2 != null && result3 != null) ? calc(result1, result2, result3) : null;
         }
     }

--- a/ScriptCompiler/AST/Statements/Expressions/IntegerLiteralNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/IntegerLiteralNode.cs
@@ -8,7 +8,7 @@ namespace ScriptCompiler.AST.Statements.Expressions {
             Value = value;
         }
 
-        public uint[] Calculate() {
+        public override uint[] Calculate(CalcContext _) {
             return new[]{Value};
         }
     }

--- a/ScriptCompiler/AST/Statements/Expressions/SizeOfNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/SizeOfNode.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace ScriptCompiler.AST.Statements.Expressions {
+    public class SizeOfNode : ExpressionNode {
+        public readonly ExpressionNode Arg;
+
+        public SizeOfNode(ExpressionNode arg) {
+            Arg = arg;
+        }
+
+        public override List<ASTNode> Children() {
+            return new List<ASTNode> {Arg};
+        }
+    }
+}

--- a/ScriptCompiler/AST/Statements/Expressions/VariableAccessNode.cs
+++ b/ScriptCompiler/AST/Statements/Expressions/VariableAccessNode.cs
@@ -5,5 +5,9 @@
         public VariableAccessNode(string identifier) {
             Identifier = identifier;
         }
+
+        public override uint[]? Calculate(CalcContext ctx) {
+            return !ctx.Static ? null : ctx.EvaluateVariable(Identifier);
+        }
     }
 }

--- a/ScriptCompiler/CodeGeneration/Assembly/Instructions/AddInstruction.cs
+++ b/ScriptCompiler/CodeGeneration/Assembly/Instructions/AddInstruction.cs
@@ -1,9 +1,12 @@
+using System.Data;
+using ScriptCompiler.Types;
+
 namespace ScriptCompiler.CodeGeneration.Assembly.Instructions {
     public class AddInstruction : BinaryArithmeticInstruction {
-        public AddInstruction(Location toLocation, Value value) : base(toLocation, value) { } 
+        public AddInstruction(Location toLocation, Value value, SType? type = null) : base(toLocation, value, type) { } 
 
         protected override string AsString() {
-            return $"ADD {ToLocation} {Value}";
+            return $"ADD{InstructionSuffix()} {ToLocation} {Value}";
         }
 
         public override bool IsNoop() {

--- a/ScriptCompiler/CodeGeneration/Assembly/Instructions/BinaryArithmeticInstruction.cs
+++ b/ScriptCompiler/CodeGeneration/Assembly/Instructions/BinaryArithmeticInstruction.cs
@@ -1,11 +1,16 @@
+using ScriptCompiler.Types;
+
 namespace ScriptCompiler.CodeGeneration.Assembly.Instructions {
     public abstract class BinaryArithmeticInstruction : Instruction {
         public readonly Value Value;
         protected readonly Location ToLocation;
+        private readonly SType _operandType;
 
-        public BinaryArithmeticInstruction(Location toLocation, Value value) {
-            ToLocation = toLocation;
-            Value      = value;
+        public BinaryArithmeticInstruction(Location toLocation, Value value, SType? operandType) {
+            operandType  ??= SType.SInteger;
+            _operandType =   operandType;
+            ToLocation   =   toLocation;
+            Value        =   value;
         }
 
         public bool SameLocation(BinaryArithmeticInstruction other) {
@@ -26,39 +31,48 @@ namespace ScriptCompiler.CodeGeneration.Assembly.Instructions {
             if (this is AddInstruction) {
                 switch (other) {
                     case AddInstruction _:
-                        result = new AddInstruction(ToLocation, ncLeft + ncRight);
+                        result = new AddInstruction(ToLocation, ncLeft + ncRight, _operandType);
                         return true;
                     case SubInstruction _:
                         var subResult = ncLeft - ncRight;
                         if (subResult >= 0) {
-                            result = new AddInstruction(ToLocation, subResult);
+                            result = new AddInstruction(ToLocation, subResult, _operandType);
                         } else {
-                            result = new SubInstruction(ToLocation, -subResult);
+                            result = new SubInstruction(ToLocation, -subResult, _operandType);
                         }
 
                         return true;
                 }
             }
-            
+
             if (this is SubInstruction) {
                 switch (other) {
                     case AddInstruction _:
                         var addResult = ncLeft - ncRight;
                         if (addResult >= 0) {
-                            result = new SubInstruction(ToLocation, addResult);
+                            result = new SubInstruction(ToLocation, addResult, _operandType);
                         } else {
-                            result = new AddInstruction(ToLocation, -addResult);
+                            result = new AddInstruction(ToLocation, -addResult, _operandType);
                         }
+
                         return true;
                     case SubInstruction _:
-                        result = new SubInstruction(ToLocation, ncLeft + ncRight);
+                        result = new SubInstruction(ToLocation, ncLeft + ncRight, _operandType);
                         return true;
                 }
             }
-            
+
             // TODO: Optimisations for mul and div
             result = null;
             return false;
+        }
+
+        protected string InstructionSuffix() {
+            if (ReferenceEquals(_operandType, SType.SFloat)) {
+                return "F";
+            }
+
+            return "";
         }
     }
 }

--- a/ScriptCompiler/CodeGeneration/Assembly/Instructions/DivInstruction.cs
+++ b/ScriptCompiler/CodeGeneration/Assembly/Instructions/DivInstruction.cs
@@ -1,9 +1,11 @@
+using ScriptCompiler.Types;
+
 namespace ScriptCompiler.CodeGeneration.Assembly.Instructions {
     public class DivInstruction : BinaryArithmeticInstruction {
-        public DivInstruction(Location toLocation, Value value) : base(toLocation, value) { }
+        public DivInstruction(Location toLocation, Value value, SType type) : base(toLocation, value, type) { }
 
         protected override string AsString() {
-            return $"DIV {ToLocation} {Value}";
+            return $"DIV{InstructionSuffix()} {ToLocation} {Value}";
         }
 
         public override bool IsNoop() {

--- a/ScriptCompiler/CodeGeneration/Assembly/Instructions/MulInstruction.cs
+++ b/ScriptCompiler/CodeGeneration/Assembly/Instructions/MulInstruction.cs
@@ -1,9 +1,11 @@
+using ScriptCompiler.Types;
+
 namespace ScriptCompiler.CodeGeneration.Assembly.Instructions {
     public class MulInstruction : BinaryArithmeticInstruction {
-        public MulInstruction(Location toLocation, Value value) : base(toLocation, value) { }
+        public MulInstruction(Location toLocation, Value value, SType type) : base(toLocation, value, type) { }
 
         protected override string AsString() {
-            return $"MUL {ToLocation} {Value}";
+            return $"MUL{InstructionSuffix()} {ToLocation} {Value}";
         }
 
         public override bool IsNoop() {

--- a/ScriptCompiler/CodeGeneration/Assembly/Instructions/PrintFloatInstruction.cs
+++ b/ScriptCompiler/CodeGeneration/Assembly/Instructions/PrintFloatInstruction.cs
@@ -1,0 +1,13 @@
+namespace ScriptCompiler.CodeGeneration.Assembly.Instructions {
+    public class PrintFloatInstruction : Instruction {
+        private readonly Location _from;
+        
+        public PrintFloatInstruction(Location from) {
+            _from = from;
+        }
+
+        protected override string AsString() {
+            return $"PRINTFLOAT {_from}";
+        }
+    }
+}

--- a/ScriptCompiler/CodeGeneration/Assembly/Instructions/PrintUIntInstruction.cs
+++ b/ScriptCompiler/CodeGeneration/Assembly/Instructions/PrintUIntInstruction.cs
@@ -1,0 +1,13 @@
+namespace ScriptCompiler.CodeGeneration.Assembly.Instructions {
+    public class PrintUIntInstruction : Instruction {
+        private readonly Location _from;
+        
+        public PrintUIntInstruction(Location from) {
+            _from = from;
+        }
+
+        protected override string AsString() {
+            return $"PRINTUINT {_from}";
+        }
+    }
+}

--- a/ScriptCompiler/CodeGeneration/Assembly/Instructions/SubInstruction.cs
+++ b/ScriptCompiler/CodeGeneration/Assembly/Instructions/SubInstruction.cs
@@ -1,9 +1,11 @@
+using ScriptCompiler.Types;
+
 namespace ScriptCompiler.CodeGeneration.Assembly.Instructions {
     public class SubInstruction : BinaryArithmeticInstruction {
-        public SubInstruction(Location toLocation, Value amount) : base(toLocation, amount) { }
+        public SubInstruction(Location toLocation, Value amount, SType? type = null) : base(toLocation, amount, type) { }
 
         protected override string AsString() {
-            return $"SUB {ToLocation} {Value}";
+            return $"SUB{InstructionSuffix()} {ToLocation} {Value}";
         }
 
         public override bool IsNoop() {

--- a/ScriptCompiler/CodeGeneration/StaticVariableRepository.cs
+++ b/ScriptCompiler/CodeGeneration/StaticVariableRepository.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 
 namespace ScriptCompiler.CodeGeneration {
-    internal class StaticVariableRepository {
+    public class StaticVariableRepository {
         public readonly Dictionary<Guid, uint[]> Values = new Dictionary<Guid, uint[]>();
         
         public Guid CreateNew(uint[] initialValue) {

--- a/ScriptCompiler/CodeGeneration/TypeIdentifier.cs
+++ b/ScriptCompiler/CodeGeneration/TypeIdentifier.cs
@@ -39,6 +39,10 @@ namespace ScriptCompiler.CodeGeneration {
             return SType.SInteger;
         }
 
+        public SType Visit(FloatLiteralNode _) {
+            return SType.SFloat;
+        }
+
         public SType Visit(StringLiteralNode _) {
             return SType.SString;
         }
@@ -50,6 +54,10 @@ namespace ScriptCompiler.CodeGeneration {
             }
 
             throw new CompileException($"Unexpected type {userType} in struct access", 0, 0);
+        }
+
+        public SType Visit(SizeOfNode node) {
+            return SType.SInteger;
         }
 
         public SType Visit(AddressOfNode node) {

--- a/ScriptCompiler/MainClass.cs
+++ b/ScriptCompiler/MainClass.cs
@@ -36,7 +36,7 @@ namespace ScriptCompiler {
 
                 Console.WriteLine(bytecodeString);
 
-                List<int> bytecode = bytecodeString.Split(',').Select(int.Parse).ToList();
+                List<uint> bytecode = bytecodeString.Split(',').Select(uint.Parse).ToList();
 
                 ScriptVm scriptVm = new ScriptVm(bytecode);
                 scriptVm.Execute();
@@ -68,7 +68,7 @@ namespace ScriptCompiler {
                 ServiceLocator.LogService.Log(LogType.Info, bytecodeString);
                 ServiceLocator.LogService.Log(LogType.Info, $"{assembled.Count} words in total");
 
-                List<int> bytecode = bytecodeString.Split(',').Select(int.Parse).ToList();
+                List<uint> bytecode = bytecodeString.Split(',').Select(uint.Parse).ToList();
                 new ScriptVm(bytecode).Execute();
             } else {
                 Console.WriteLine($"Unexpected argument {args[0]}");

--- a/ScriptCompiler/Parsing/Parser.cs
+++ b/ScriptCompiler/Parsing/Parser.cs
@@ -37,8 +37,8 @@ namespace ScriptCompiler.Parsing {
         }
 
         private readonly string _contents;
-        private Lexer _lexer;
-        private List<LexToken> _cachedTokens = new List<LexToken>();
+        private readonly Lexer _lexer;
+        private readonly List<LexToken> _cachedTokens = new List<LexToken>();
 
         private readonly List<PrefixParseRule> _prefixExpressionParseTable;
 
@@ -55,7 +55,10 @@ namespace ScriptCompiler.Parsing {
 
             _prefixExpressionParseTable = new List<PrefixParseRule> {
                 new PrefixParseRule(t => t is IntegerToken, t => new IntegerLiteralNode(((IntegerToken) t).Content)),
+                new PrefixParseRule(t => t is FloatToken, t => new FloatLiteralNode(((FloatToken) t).Content)),
                 new PrefixParseRule(t => t is StringToken, t => new StringLiteralNode(((StringToken) t).Content)),
+                new PrefixParseRule(t => t is IdentifierToken("sizeof"),
+                                        _ => new SizeOfNode(ParseExpressionPrecedence(Precedence.Factor))),
                 new PrefixParseRule(t => t is IdentifierToken,
                                     t => new VariableAccessNode(((IdentifierToken) t).Content)),
                 new PrefixParseRule(t => t is SymbolToken("("), _ => ParseGrouping()),

--- a/ScriptCompiler/Types/SType.cs
+++ b/ScriptCompiler/Types/SType.cs
@@ -1,10 +1,14 @@
-﻿namespace ScriptCompiler.Types {
+﻿using System.Reflection.Metadata.Ecma335;
+
+namespace ScriptCompiler.Types {
     public class SType {
         public static readonly SType SVoid = new SType("void", 0);
         public static readonly SType SNoType = new SType("NO TYPE");
         public static readonly SType SInteger = new SType("int");
+        public static readonly SType SUInteger = new SType("uint");
         public static readonly SType SBool = new SType("bool");
         public static readonly SType SChar = new SType("char");
+        public static readonly SType SFloat = new SType("float");
         public static readonly SType SString = new ReferenceType(SChar);
         public static readonly SType SGenericPtr = new ReferenceType(SNoType);
 
@@ -50,6 +54,10 @@
             switch (nodeTypeString) {
                 case "int":
                     return SInteger;
+                case "uint":
+                    return SUInteger;
+                case "float":
+                    return SFloat;
                 case "bool":
                     return SBool;
                 case "char":

--- a/ScriptCompiler/Types/UserType.cs
+++ b/ScriptCompiler/Types/UserType.cs
@@ -7,7 +7,6 @@ namespace ScriptCompiler.Types {
         private readonly List<(string name, SType type)> _fields;
         private readonly Dictionary<string, int> _fieldOffsets = new Dictionary<string, int>();
         
-
         public UserType(string name, List<(string, SType)> fields) : base(name, fields.Sum(tuple => tuple.Item2.Length)) {
             _fields = fields;
 

--- a/ScriptCompiler/mem.fscr
+++ b/ScriptCompiler/mem.fscr
@@ -1,18 +1,10 @@
 // The malloc heap works as follows:
 // mallocBase                    -> first 'page' of malloced data
-// mallocStatus (mallocBase - 1) -> whether malloc is initialised or not
 // mallocHead   (mallocBase - 2) -> state of malloc 'head'  (i.e. first page that has never been allocated)
 func int @malloc(int size) {
     static int @mallocBase   = 2147483648;
-    static int @mallocStatus = mallocBase - 1;
-    static int @mallocHead   = mallocBase - 2;
+    static int @mallocHead   = mallocBase - 1;
     static int pageLength    = 1024;
-    
-    if !mallocStatus == 0 {
-        print "Malloc initialisation in progress";
-        !mallocStatus = 1;
-        !mallocHead   = 0;
-    }
     
     // Allocate the first space that has never  been used
     int @allocatedPageStart = mallocBase + (!mallocHead * pageLength);
@@ -22,20 +14,23 @@ func int @malloc(int size) {
     !mallocHead = !mallocHead + thisPageLength;
     
     // Return the pointer we calculated for their page
-    print "Next free page:";
-    print !mallocHead;
     return allocatedPageStart;
 }
 
 struct Player {
     int health;
     int mana;
+    int coins;
 }
 
-Player @x = malloc(2);
-Player @y = malloc(2);
+Player @x = malloc(sizeof Player);
+Player @y = malloc(sizeof Player);
 
 x->health = 5;
+
 y->health = 10;
+x->coins = 14;
+y->coins = x->coins + 15;
 print x->health;
 print y->health;
+print y->coins;

--- a/ScriptCompiler/test.fscr
+++ b/ScriptCompiler/test.fscr
@@ -1,9 +1,7 @@
-for int i = 0; i < 2; i = i + 1 {
-    for int j = 0; j < 2; j = j + 1 {
-        for int k = 0; k < 2; k = k + 1 {
-            print i;
-            print j;
-            print k;
-        }
-    }
-}
+float x = 0.5;
+float y = 0.5f;
+float z = 1f;
+float a = 0.25f;
+
+print x + y + z;
+print 0.5f;


### PR DESCRIPTION
* Switch to using `uint` for representing bytecode
* Add formal `uint` type to language
* Add `float` to language and new `addf`, `subf`, `mulf`, and `difv` operations to the bytecode
* Add more `constexpr` evaluators
* Add `sizeof` operator which can work on type name literals or instances of a type